### PR TITLE
CI: Fix run for pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,26 +1,13 @@
 name: CI
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:
     runs-on: macOS-latest
 
-    env:
-      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-
     steps:
     - uses: actions/checkout@v2
-    - name: Setup SSH Keys and known_hosts
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.CERTS_REPO_CERT }}" > ~/.ssh/certs_rsa
-        chmod 600 ~/.ssh/certs_rsa
-        ssh-add ~/.ssh/certs_rsa
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-    - name: Install firebase tool
-      run: |
-        curl -sL firebase.tools | bash
     - name: Build
       run: |
         fastlane setup

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,5 +10,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: |
-        fastlane setup
-        fastlane build_snapshot
+        pod install
+        xcodebuild -workspace Legio.xcworkspace -scheme Legio CODE_SIGNING_ALLOWED="NO"


### PR DESCRIPTION
Т.к. гитхаб не дает пулл-реквестам доступ к секретам, для них сделал отдельную конфигурацию где только сборка без подписи кода